### PR TITLE
Add clang-format support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,98 @@
+# Basic Formatting
+BasedOnStyle: Google
+ColumnLimit: 120
+TabWidth: 4
+UseTab: false
+MaxEmptyLinesToKeep: 4
+
+# Language
+Language: Cpp
+Standard: Cpp11
+
+# Indentation
+AccessModifierOffset: -4
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 8
+IndentCaseLabels: false
+IndentPPDirectives: AfterHash
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+NamespaceIndentation: Inner
+
+# Includes
+IncludeBlocks: Preserve
+SortIncludes: true
+
+# Alignment
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands: true
+AlignTrailingComments: true
+DerivePointerAlignment: false
+PointerAlignment: Middle
+
+# Wrapping and Breaking
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterExternBlock: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakStringLiterals: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+Cpp11BracedListStyle: true
+
+# Spaces
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+## These aren't recognized by the version of clang-format in visual studio 17
+#SpaceBeforeCpp11BracedList: false
+#SpaceBeforeCtorInitializerColon: true
+#SpaceBeforeInheritanceColon: true
+#SpaceBeforeRangeBasedForLoopColon: true
+#BreakInheritanceList: BeforeComma
+
+# Other
+CommentPragmas: '^(!FIXME!|!TODO!|ToDo:)'
+CompactNamespaces: false
+DisableFormat: false
+FixNamespaceComments: true
+#ForEachMacros: ''
+KeepEmptyLinesAtTheStartOfBlocks: true
+ReflowComments: false
+SortUsingDeclarations: true

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+find src tests/src -iname "*.hpp" -o -iname "*.cpp" \
+| xargs clang-format -i

--- a/src/BoxedOptional.hpp
+++ b/src/BoxedOptional.hpp
@@ -8,13 +8,11 @@ struct BoxedOptional {
 
     BoxedOptional() = default;
 
-    BoxedOptional(T value): value{std::make_unique<T>(std::move(value))} {}
+    BoxedOptional(T value) : value{std::make_unique<T>(std::move(value))} {}
 
-    BoxedOptional(BoxedOptional const & optional) {
-        *this = optional;
-    }
+    BoxedOptional(BoxedOptional const & optional) { *this = optional; }
 
-    BoxedOptional & operator = (BoxedOptional const & optional) {
+    BoxedOptional & operator=(BoxedOptional const & optional) {
         reset();
         if (optional) {
             value = std::make_unique<T>(*optional.value);
@@ -22,11 +20,9 @@ struct BoxedOptional {
         return *this;
     }
 
-    BoxedOptional(BoxedOptional && optional) {
-        *this = std::move(optional);
-    }
+    BoxedOptional(BoxedOptional && optional) { *this = std::move(optional); }
 
-    BoxedOptional & operator = (BoxedOptional && optional) {
+    BoxedOptional & operator=(BoxedOptional && optional) {
         reset();
         if (optional) {
             value = std::move(optional.value);
@@ -34,39 +30,26 @@ struct BoxedOptional {
         return *this;
     }
 
-    void reset() {
-        value.reset();
-    }
+    void reset() { value.reset(); }
 
-    bool has_value() const {
-        return value != nullptr;
-    }
+    bool has_value() const { return value != nullptr; }
 
-    explicit operator bool() const {
-        return has_value();
-    }
+    explicit operator bool() const { return has_value(); }
 
-    T & operator * () {
-        return *value;
-    }
+    T & operator*() { return *value; }
 
-    T const & operator * () const {
-        return *value;
-    }
+    T const & operator*() const { return *value; }
 
-    T * operator -> () {
-        return value.get();
-    }
+    T * operator->() { return value.get(); }
 
-    T const * operator -> () const {
-        return value.get();
-    }
+    T const * operator->() const { return value.get(); }
 
 private:
     std::unique_ptr<T> value;
 };
 
-template <typename T> bool operator == (BoxedOptional<T> const & lhs, BoxedOptional<T> const & rhs) {
+template <typename T>
+bool operator==(BoxedOptional<T> const & lhs, BoxedOptional<T> const & rhs) {
     if (lhs.has_value() != rhs.has_value()) {
         return false;
     }
@@ -76,32 +59,33 @@ template <typename T> bool operator == (BoxedOptional<T> const & lhs, BoxedOptio
     return *lhs == *rhs;
 }
 
-template <typename T> bool operator != (BoxedOptional<T> const & lhs, BoxedOptional<T> const & rhs) {
+template <typename T>
+bool operator!=(BoxedOptional<T> const & lhs, BoxedOptional<T> const & rhs) {
     return !(lhs == rhs);
 }
 
-}
+} // namespace caffql
 
 namespace nlohmann {
-    template <typename T>
-    struct adl_serializer<caffql::BoxedOptional<T>> {
-        static void to_json(json & json, caffql::BoxedOptional<T> const & opt) {
-            if (opt.has_value()) {
-                json = *opt;
-            } else {
-                json = nullptr;
-            }
+template <typename T>
+struct adl_serializer<caffql::BoxedOptional<T>> {
+    static void to_json(json & json, caffql::BoxedOptional<T> const & opt) {
+        if (opt.has_value()) {
+            json = *opt;
+        } else {
+            json = nullptr;
         }
+    }
 
-        static void from_json(const json & json, caffql::BoxedOptional<T> & opt) {
-            if (json.is_null()) {
-                opt.reset();
-            } else {
-                opt = json.get<T>();
-            }
+    static void from_json(const json & json, caffql::BoxedOptional<T> & opt) {
+        if (json.is_null()) {
+            opt.reset();
+        } else {
+            opt = json.get<T>();
         }
-    };
-}
+    }
+};
+} // namespace nlohmann
 
 namespace caffql {
 
@@ -115,4 +99,4 @@ void get_value_to(Json const & json, char const * key, BoxedOptional<T> & target
     }
 }
 
-}
+} // namespace caffql

--- a/src/CodeGeneration.cpp
+++ b/src/CodeGeneration.cpp
@@ -69,20 +69,20 @@ std::vector<Type> sortCustomTypesByDependencyOrder(std::vector<Type> const & typ
 
     auto isCustomType = [](TypeKind kind) {
         switch (kind) {
-            case TypeKind::Object:
-            case TypeKind::Interface:
-            case TypeKind::Union:
-            case TypeKind::Enum:
-            case TypeKind::InputObject:
-                return true;
+        case TypeKind::Object:
+        case TypeKind::Interface:
+        case TypeKind::Union:
+        case TypeKind::Enum:
+        case TypeKind::InputObject:
+            return true;
 
-            case TypeKind::Scalar:
-            case TypeKind::List:
-            case TypeKind::NonNull:
-                return false;
+        case TypeKind::Scalar:
+        case TypeKind::List:
+        case TypeKind::NonNull:
+            return false;
         }
 
-        throw std::invalid_argument{ "Invalid TypeKind value: " + std::to_string(static_cast<int>(kind)) };
+        throw std::invalid_argument{"Invalid TypeKind value: " + std::to_string(static_cast<int>(kind))};
     };
 
     for (auto const & type : types) {
@@ -93,7 +93,7 @@ std::vector<Type> sortCustomTypesByDependencyOrder(std::vector<Type> const & typ
 
         unordered_set<string> dependencies;
 
-        auto addDependency = [&](auto const &dependency) {
+        auto addDependency = [&](auto const & dependency) {
             if (dependency.name && isCustomType(dependency.kind)) {
                 typesToDependents[*dependency.name].insert(type.name);
                 dependencies.insert(*dependency.name);
@@ -137,7 +137,7 @@ std::vector<Type> sortCustomTypesByDependencyOrder(std::vector<Type> const & typ
             }
         }
 
-        for (auto const &addedName : addedTypeNames) {
+        for (auto const & addedName : addedTypeNames) {
             typesToDependencies.erase(addedName);
         }
 
@@ -149,9 +149,7 @@ std::vector<Type> sortCustomTypesByDependencyOrder(std::vector<Type> const & typ
     return sortedTypes;
 }
 
-std::string indent(size_t indentation) {
-    return std::string(indentation * spacesPerIndent, ' ');
-}
+std::string indent(size_t indentation) { return std::string(indentation * spacesPerIndent, ' '); }
 
 std::string generateDescription(std::optional<std::string> const & optionalDescription, size_t indentation) {
     if (!optionalDescription) {
@@ -246,7 +244,8 @@ std::string generateEnumSerialization(Type const & type, size_t indentation) {
     generated += indent(valueIndentation) + "{" + type.name + "::" + unknownCaseName + ", nullptr},\n";
 
     for (auto const & value : type.enumValues) {
-        generated += indent(valueIndentation) + "{" + type.name + "::" + screamingSnakeCaseToPascalCase(value.name) + ", \"" + value.name + "\"},\n";
+        generated += indent(valueIndentation) + "{" + type.name + "::" + screamingSnakeCaseToPascalCase(value.name) +
+                     ", \"" + value.name + "\"},\n";
     }
 
     generated += indent(indentation) + "});\n\n";
@@ -272,20 +271,20 @@ Scalar scalarType(std::string const & name) {
 
 std::string cppScalarName(Scalar scalar) {
     switch (scalar) {
-        case Scalar::Int:
-            return "int32_t";
-        case Scalar::Float:
-            return "double";
-        case Scalar::String:
-            return "std::string";
-        case Scalar::ID:
-            return cppIdTypeName;
-        case Scalar::Boolean:
-            return "bool";
+    case Scalar::Int:
+        return "int32_t";
+    case Scalar::Float:
+        return "double";
+    case Scalar::String:
+        return "std::string";
+    case Scalar::ID:
+        return cppIdTypeName;
+    case Scalar::Boolean:
+        return "bool";
     }
 
 
-    throw std::invalid_argument{ "Invalid Scalar value: " + std::to_string(static_cast<int>(scalar)) };
+    throw std::invalid_argument{"Invalid Scalar value: " + std::to_string(static_cast<int>(scalar))};
 }
 
 std::string cppTypeName(TypeRef const & type, bool shouldCheckNullability) {
@@ -294,44 +293,44 @@ std::string cppTypeName(TypeRef const & type, bool shouldCheckNullability) {
     }
 
     switch (type.kind) {
-        case TypeKind::Object:
-        case TypeKind::Interface:
-        case TypeKind::Union:
-        case TypeKind::Enum:
-        case TypeKind::InputObject:
-            return type.name.value();
+    case TypeKind::Object:
+    case TypeKind::Interface:
+    case TypeKind::Union:
+    case TypeKind::Enum:
+    case TypeKind::InputObject:
+        return type.name.value();
 
-        case TypeKind::Scalar:
-            return cppScalarName(scalarType(type.name.value()));
+    case TypeKind::Scalar:
+        return cppScalarName(scalarType(type.name.value()));
 
-        case TypeKind::List:
-            return "std::vector<" + cppTypeName(*type.ofType) + ">";
+    case TypeKind::List:
+        return "std::vector<" + cppTypeName(*type.ofType) + ">";
 
-        case TypeKind::NonNull:
-            return cppTypeName(*type.ofType, false);
+    case TypeKind::NonNull:
+        return cppTypeName(*type.ofType, false);
     }
 
-    throw std::invalid_argument{ "Invalid TypeKind value: " + std::to_string(static_cast<int>(type.kind)) };
+    throw std::invalid_argument{"Invalid TypeKind value: " + std::to_string(static_cast<int>(type.kind))};
 }
 
 std::string graphqlTypeName(TypeRef const & type) {
     switch (type.kind) {
-        case TypeKind::Scalar:
-        case TypeKind::Object:
-        case TypeKind::Union:
-        case TypeKind::Interface:
-        case TypeKind::Enum:
-        case TypeKind::InputObject:
-            return type.name.value();
+    case TypeKind::Scalar:
+    case TypeKind::Object:
+    case TypeKind::Union:
+    case TypeKind::Interface:
+    case TypeKind::Enum:
+    case TypeKind::InputObject:
+        return type.name.value();
 
-        case TypeKind::List:
-            return "[" + graphqlTypeName(*type.ofType) + "]";
+    case TypeKind::List:
+        return "[" + graphqlTypeName(*type.ofType) + "]";
 
-        case TypeKind::NonNull:
-            return graphqlTypeName(*type.ofType) + "!";
+    case TypeKind::NonNull:
+        return graphqlTypeName(*type.ofType) + "!";
     }
 
-    throw std::invalid_argument{ "Invalid TypeKind value: " + std::to_string(static_cast<int>(type.kind)) };
+    throw std::invalid_argument{"Invalid TypeKind value: " + std::to_string(static_cast<int>(type.kind))};
 }
 
 std::string cppVariant(std::vector<TypeRef> const & possibleTypes, std::string const & unknownTypeName) {
@@ -344,7 +343,8 @@ std::string cppVariant(std::vector<TypeRef> const & possibleTypes, std::string c
 }
 
 std::string generateDeserializationFunctionDeclaration(std::string const & typeName, size_t indentation) {
-    return indent(indentation) + "inline void from_json(" + cppJsonTypeName + " const & json, " + typeName + " & value) {\n";
+    return indent(indentation) + "inline void from_json(" + cppJsonTypeName + " const & json, " + typeName +
+           " & value) {\n";
 }
 
 std::string generateFieldDeserialization(Field const & field, size_t indentation) {
@@ -365,7 +365,8 @@ std::string generateFieldDeserialization(Field const & field, size_t indentation
     return generated;
 }
 
-std::string generateVariantDeserialization(Type const & type, std::string const & constructUnknown, size_t indentation) {
+std::string generateVariantDeserialization(
+        Type const & type, std::string const & constructUnknown, size_t indentation) {
     std::string generated;
 
     generated += generateDeserializationFunctionDeclaration(type.name, indentation);
@@ -408,8 +409,8 @@ std::string generateInterface(Type const & type, size_t indentation) {
         auto const typeNameConstRef = typeName + " const & ";
         interface += generateDescription(field.description, fieldIndentation);
         interface += indent(fieldIndentation) + typeNameConstRef + field.name + "() const {\n";
-        interface += indent(fieldIndentation + 1) + "return visit([](auto const & implementation) -> "
-        + typeNameConstRef + "{\n";
+        interface += indent(fieldIndentation + 1) + "return visit([](auto const & implementation) -> " +
+                     typeNameConstRef + "{\n";
         interface += indent(fieldIndentation + 2) + "return implementation." + field.name + ";\n";
         interface += indent(fieldIndentation + 1) + "}, implementation);\n";
         interface += indent(fieldIndentation) + "}\n\n";
@@ -438,8 +439,8 @@ std::string generateInterfaceUnknownCaseDeserialization(Type const & type, size_
 }
 
 std::string generateInterfaceDeserialization(Type const & type, size_t indentation) {
-    return generateInterfaceUnknownCaseDeserialization(type, indentation)
-    + generateVariantDeserialization(type, unknownCaseName + type.name + "(json)", indentation);
+    return generateInterfaceUnknownCaseDeserialization(type, indentation) +
+           generateVariantDeserialization(type, unknownCaseName + type.name + "(json)", indentation);
 }
 
 std::string generateUnion(Type const & type, size_t indentation) {
@@ -448,7 +449,8 @@ std::string generateUnion(Type const & type, size_t indentation) {
     auto const unknownTypeName = unknownCaseName + type.name;
     generated += indent(indentation) + "using " + unknownTypeName + " = monostate;\n";
     generated += generateDescription(type.description, indentation);
-    generated += indent(indentation) + "using " + type.name + " = " + cppVariant(type.possibleTypes, unknownTypeName) + ";\n\n";
+    generated += indent(indentation) + "using " + type.name + " = " + cppVariant(type.possibleTypes, unknownTypeName) +
+                 ";\n\n";
     return generated;
 }
 
@@ -513,14 +515,16 @@ std::string generateInputObject(Type const & type, size_t indentation) {
 }
 
 template <typename FieldType>
-static std::string generateFieldSerialization(FieldType const & field, const std::string & fieldPrefix, const std::string & jsonName, size_t indentation) {
+static std::string generateFieldSerialization(
+        FieldType const & field, const std::string & fieldPrefix, const std::string & jsonName, size_t indentation) {
     return indent(indentation) + jsonName + "[\"" + field.name + "\"] = " + fieldPrefix + field.name + ";\n";
 }
 
 std::string generateInputObjectSerialization(Type const & type, size_t indentation) {
     std::string generated;
 
-    generated += indent(indentation) + "inline void to_json(" + cppJsonTypeName + " & json, " + type.name + " const & value) {\n";
+    generated += indent(indentation) + "inline void to_json(" + cppJsonTypeName + " & json, " + type.name +
+                 " const & value) {\n";
 
     for (auto const & field : type.inputFields) {
         generated += generateFieldSerialization(field, "value.", "json", indentation + 1);
@@ -533,22 +537,27 @@ std::string generateInputObjectSerialization(Type const & type, size_t indentati
 
 std::string operationQueryName(Operation operation) {
     switch (operation) {
-        case Operation::Query:
-            return "query";
-        case Operation::Mutation:
-            return "mutation";
-        case Operation::Subscription:
-            return "subscription";
+    case Operation::Query:
+        return "query";
+    case Operation::Mutation:
+        return "mutation";
+    case Operation::Subscription:
+        return "subscription";
     }
 
-    throw std::invalid_argument{ "Invalid Operation value: " + std::to_string(static_cast<int>(operation)) };
+    throw std::invalid_argument{"Invalid Operation value: " + std::to_string(static_cast<int>(operation))};
 }
 
 std::string appendNameToVariablePrefix(std::string const & variablePrefix, std::string const & name) {
     return variablePrefix.empty() ? uncapitalize(name) : variablePrefix + capitalize(name);
 }
 
-std::string generateQueryField(Field const & field, TypeMap const & typeMap, std::string const & variablePrefix, std::vector<QueryVariable> & variables, size_t indentation) {
+std::string generateQueryField(
+        Field const & field,
+        TypeMap const & typeMap,
+        std::string const & variablePrefix,
+        std::vector<QueryVariable> & variables,
+        size_t indentation) {
     std::string generated;
 
     generated += indent(indentation) + field.name;
@@ -566,7 +575,12 @@ std::string generateQueryField(Field const & field, TypeMap const & typeMap, std
     auto const & underlyingFieldType = field.type.underlyingType();
     if (underlyingFieldType.kind != TypeKind::Scalar && underlyingFieldType.kind != TypeKind::Enum) {
         generated += " {\n";
-        generated += generateQueryFields(typeMap.at(underlyingFieldType.name.value()), typeMap, appendNameToVariablePrefix(variablePrefix, underlyingFieldType.name.value()), variables, indentation + 1);
+        generated += generateQueryFields(
+                typeMap.at(underlyingFieldType.name.value()),
+                typeMap,
+                appendNameToVariablePrefix(variablePrefix, underlyingFieldType.name.value()),
+                variables,
+                indentation + 1);
         generated += indent(indentation) + "}";
     }
 
@@ -575,7 +589,12 @@ std::string generateQueryField(Field const & field, TypeMap const & typeMap, std
     return generated;
 }
 
-std::string generateQueryFields(Type const & type, TypeMap const & typeMap, std::string const & variablePrefix, std::vector<QueryVariable> & variables, size_t indentation) {
+std::string generateQueryFields(
+        Type const & type,
+        TypeMap const & typeMap,
+        std::string const & variablePrefix,
+        std::vector<QueryVariable> & variables,
+        size_t indentation) {
     std::string generated;
 
     if (!type.possibleTypes.empty()) {
@@ -583,19 +602,26 @@ std::string generateQueryFields(Type const & type, TypeMap const & typeMap, std:
 
         for (auto const & possibleType : type.possibleTypes) {
             generated += indent(indentation) + "...on " + possibleType.name.value() + " {\n";
-            generated += generateQueryFields(typeMap.at(possibleType.name.value()), typeMap, appendNameToVariablePrefix(variablePrefix, possibleType.name.value()), variables, indentation + 1);
+            generated += generateQueryFields(
+                    typeMap.at(possibleType.name.value()),
+                    typeMap,
+                    appendNameToVariablePrefix(variablePrefix, possibleType.name.value()),
+                    variables,
+                    indentation + 1);
             generated += indent(indentation) + "}\n";
         }
     } else {
         for (auto const & field : type.fields) {
-            generated += generateQueryField(field, typeMap, appendNameToVariablePrefix(variablePrefix, field.name), variables, indentation);
+            generated += generateQueryField(
+                    field, typeMap, appendNameToVariablePrefix(variablePrefix, field.name), variables, indentation);
         }
     }
 
     return generated;
 }
 
-QueryDocument generateQueryDocument(Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation) {
+QueryDocument generateQueryDocument(
+        Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation) {
     QueryDocument document;
     auto & query = document.query;
     auto & variables = document.variables;
@@ -619,42 +645,42 @@ bool shouldPassByReferenceToRequestFunction(TypeRef const & type) {
     auto currentType = &type;
     while (true) {
         switch (currentType->kind) {
-            case TypeKind::Scalar:
-                switch (scalarType(currentType->name.value())) {
-                    case Scalar::Int:
-                    case Scalar::Float:
-                    case Scalar::Boolean:
-                        return false;
-
-                    case Scalar::String:
-                    case Scalar::ID:
-                        return true;
-                }
-                break;
-
-            case TypeKind::Enum:
+        case TypeKind::Scalar:
+            switch (scalarType(currentType->name.value())) {
+            case Scalar::Int:
+            case Scalar::Float:
+            case Scalar::Boolean:
                 return false;
 
-            case TypeKind::Object:
-            case TypeKind::Interface:
-            case TypeKind::Union:
-            case TypeKind::InputObject:
-            case TypeKind::List:
+            case Scalar::String:
+            case Scalar::ID:
                 return true;
+            }
+            break;
 
-            case TypeKind::NonNull:
-                if (currentType->ofType) {
-                    currentType = &*currentType->ofType;
-                    continue;
-                } else {
-                    throw std::runtime_error{"Nonnull should be wrapped a type"};
-                }
+        case TypeKind::Enum:
+            return false;
+
+        case TypeKind::Object:
+        case TypeKind::Interface:
+        case TypeKind::Union:
+        case TypeKind::InputObject:
+        case TypeKind::List:
+            return true;
+
+        case TypeKind::NonNull:
+            if (currentType->ofType) {
+                currentType = &*currentType->ofType;
+                continue;
+            } else {
+                throw std::runtime_error{"Nonnull should be wrapped a type"};
+            }
         }
     }
-
 }
 
-std::string generateOperationRequestFunction(Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation) {
+std::string generateOperationRequestFunction(
+        Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation) {
     auto const functionIndentation = indentation + 1;
     auto const queryIndentation = functionIndentation + 1;
 
@@ -678,14 +704,16 @@ std::string generateOperationRequestFunction(Field const & field, Operation oper
     generated += ") {\n";
 
     // Use raw string literal for the query.
-    generated += indent(functionIndentation) + cppJsonTypeName + " query = R\"(\n" + document.query + indent(functionIndentation) + ")\";\n";
+    generated += indent(functionIndentation) + cppJsonTypeName + " query = R\"(\n" + document.query +
+                 indent(functionIndentation) + ")\";\n";
     generated += indent(functionIndentation) + cppJsonTypeName + " variables;\n";
 
     for (auto const & variable : document.variables) {
         generated += generateFieldSerialization(variable, "", "variables", functionIndentation);
     }
 
-    generated += indent(functionIndentation) + "return {{\"query\", std::move(query)}, {\"variables\", std::move(variables)}};\n";
+    generated += indent(functionIndentation) +
+                 "return {{\"query\", std::move(query)}, {\"variables\", std::move(variables)}};\n";
 
     generated += indent(indentation) + "}\n\n";
 
@@ -728,7 +756,8 @@ std::string generateOperationResponseFunction(Field const & field, size_t indent
     return generated;
 }
 
-std::string generateOperationType(Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation) {
+std::string generateOperationType(
+        Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation) {
     auto const document = generateQueryDocument(field, operation, typeMap, 0);
 
     std::string generated;
@@ -744,7 +773,8 @@ std::string generateOperationType(Field const & field, Operation operation, Type
     return generated;
 }
 
-std::string generateOperationTypes(Type const & type, Operation operation, TypeMap const & typeMap, size_t indentation) {
+std::string generateOperationTypes(
+        Type const & type, Operation operation, TypeMap const & typeMap, size_t indentation) {
     std::string generated;
 
     generated += indent(indentation) + "namespace " + type.name + " {\n\n";
@@ -764,7 +794,8 @@ std::string generateGraphqlErrorType(size_t indentation) {
     generated += indent(indentation + 1) + "std::string message;\n";
     generated += indent(indentation) + "};\n\n";
     generated += indent(indentation) + "template <typename Data>\n";
-    generated += indent(indentation) + "using GraphqlResponse = variant<Data, std::vector<" + grapqlErrorTypeName + ">>;\n\n";
+    generated += indent(indentation) + "using GraphqlResponse = variant<Data, std::vector<" + grapqlErrorTypeName +
+                 ">>;\n\n";
 
     return generated;
 }
@@ -781,13 +812,14 @@ std::string generateGraphqlErrorDeserialization(size_t indentation) {
 
 std::string algrebraicNamespaceName(AlgebraicNamespace algebraicNamespace) {
     switch (algebraicNamespace) {
-        case AlgebraicNamespace::Std:
-            return "std";
-        case AlgebraicNamespace::Absl:
-            return "absl";
+    case AlgebraicNamespace::Std:
+        return "std";
+    case AlgebraicNamespace::Absl:
+        return "absl";
     }
 
-    throw std::invalid_argument{ "Invalid AlgebraicNamespace value: " + std::to_string(static_cast<int>(algebraicNamespace)) };
+    throw std::invalid_argument{"Invalid AlgebraicNamespace value: " +
+                                std::to_string(static_cast<int>(algebraicNamespace))};
 }
 
 static std::string generateOptionalSerialization(AlgebraicNamespace algebraicNamespace) {
@@ -796,15 +828,15 @@ static std::string generateOptionalSerialization(AlgebraicNamespace algebraicNam
     char const * variantInclude;
 
     switch (algebraicNamespace) {
-        case AlgebraicNamespace::Std:
-            optionalInclude = "<optional>";
-            variantInclude = "<variant>";
-            break;
+    case AlgebraicNamespace::Std:
+        optionalInclude = "<optional>";
+        variantInclude = "<variant>";
+        break;
 
-        case AlgebraicNamespace::Absl:
-            optionalInclude = "\"absl/types/optional.h\"";
-            variantInclude = "\"absl/types/variant.h\"";
-            break;
+    case AlgebraicNamespace::Absl:
+        optionalInclude = "\"absl/types/optional.h\"";
+        variantInclude = "\"absl/types/variant.h\"";
+        break;
     }
 
 
@@ -837,12 +869,21 @@ namespace nlohmann {
 )";
 
     std::string buffer(1000, '\0');
-    int len = snprintf(&buffer[0], buffer.size(), format, optionalInclude, variantInclude, namespaceName.c_str(), namespaceName.c_str(), namespaceName.c_str());
+    int len = snprintf(
+            &buffer[0],
+            buffer.size(),
+            format,
+            optionalInclude,
+            variantInclude,
+            namespaceName.c_str(),
+            namespaceName.c_str(),
+            namespaceName.c_str());
     buffer.resize(len);
     return buffer;
 }
 
-std::string generateTypes(Schema const & schema, std::string const & generatedNamespace, AlgebraicNamespace algebraicNamespace) {
+std::string generateTypes(
+        Schema const & schema, std::string const & generatedNamespace, AlgebraicNamespace algebraicNamespace) {
     auto const sortedTypes = sortCustomTypesByDependencyOrder(schema.types);
 
     TypeMap typeMap;
@@ -854,7 +895,7 @@ std::string generateTypes(Schema const & schema, std::string const & generatedNa
     std::string source;
 
     source +=
-    R"(// This file was automatically generated and should not be edited.
+            R"(// This file was automatically generated and should not be edited.
 #pragma once
 
 #include <memory>
@@ -871,9 +912,10 @@ std::string generateTypes(Schema const & schema, std::string const & generatedNa
     source += indent(typeIndentation) + "using " + cppIdTypeName + " = std::string;\n";
 
     auto useAlgebraic = [&](char const * name) {
-        source += indent(typeIndentation) + "using " + algrebraicNamespaceName(algebraicNamespace) + "::" + name + ";\n";
+        source +=
+                indent(typeIndentation) + "using " + algrebraicNamespaceName(algebraicNamespace) + "::" + name + ";\n";
     };
-    
+
     useAlgebraic("optional");
     useAlgebraic("variant");
     useAlgebraic("monostate");
@@ -889,43 +931,43 @@ std::string generateTypes(Schema const & schema, std::string const & generatedNa
         };
 
         switch (type.kind) {
-            case TypeKind::Object:
-                if (isOperationType(schema.queryType)) {
-                    source += generateOperationTypes(type, Operation::Query, typeMap, typeIndentation);
-                } else if (isOperationType(schema.mutationType)) {
-                    source += generateOperationTypes(type, Operation::Mutation, typeMap, typeIndentation);
-                } else if (isOperationType(schema.subscriptionType)) {
-                    source += generateOperationTypes(type, Operation::Subscription, typeMap, typeIndentation);
-                } else {
-                    source += generateObject(type, typeIndentation);
-                    source += generateObjectDeserialization(type, typeIndentation);
-                }
-                break;
+        case TypeKind::Object:
+            if (isOperationType(schema.queryType)) {
+                source += generateOperationTypes(type, Operation::Query, typeMap, typeIndentation);
+            } else if (isOperationType(schema.mutationType)) {
+                source += generateOperationTypes(type, Operation::Mutation, typeMap, typeIndentation);
+            } else if (isOperationType(schema.subscriptionType)) {
+                source += generateOperationTypes(type, Operation::Subscription, typeMap, typeIndentation);
+            } else {
+                source += generateObject(type, typeIndentation);
+                source += generateObjectDeserialization(type, typeIndentation);
+            }
+            break;
 
-            case TypeKind::Interface:
-                source += generateInterface(type, typeIndentation);
-                source += generateInterfaceDeserialization(type, typeIndentation);
-                break;
+        case TypeKind::Interface:
+            source += generateInterface(type, typeIndentation);
+            source += generateInterfaceDeserialization(type, typeIndentation);
+            break;
 
-            case TypeKind::Union:
-                source += generateUnion(type, typeIndentation);
-                source += generateUnionDeserialization(type, typeIndentation);
-                break;
+        case TypeKind::Union:
+            source += generateUnion(type, typeIndentation);
+            source += generateUnionDeserialization(type, typeIndentation);
+            break;
 
-            case TypeKind::Enum:
-                source += generateEnum(type, typeIndentation);
-                source += generateEnumSerialization(type, typeIndentation);
-                break;
+        case TypeKind::Enum:
+            source += generateEnum(type, typeIndentation);
+            source += generateEnumSerialization(type, typeIndentation);
+            break;
 
-            case TypeKind::InputObject:
-                source += generateInputObject(type, typeIndentation);
-                source += generateInputObjectSerialization(type, typeIndentation);
-                break;
+        case TypeKind::InputObject:
+            source += generateInputObject(type, typeIndentation);
+            source += generateInputObjectSerialization(type, typeIndentation);
+            break;
 
-            case TypeKind::Scalar:
-            case TypeKind::List:
-            case TypeKind::NonNull:
-                break;
+        case TypeKind::Scalar:
+        case TypeKind::List:
+        case TypeKind::NonNull:
+            break;
         }
     }
 
@@ -934,4 +976,4 @@ std::string generateTypes(Schema const & schema, std::string const & generatedNa
     return source;
 }
 
-}
+} // namespace caffql

--- a/src/CodeGeneration.hpp
+++ b/src/CodeGeneration.hpp
@@ -1,20 +1,14 @@
 #pragma once
-#include "BoxedOptional.hpp"
 #include <unordered_set>
+#include "BoxedOptional.hpp"
 
-#define CAFFQL_DEFINE_EQUALS(T, equals) \
-inline bool operator == (T const & lhs, T const & rhs) { \
-equals \
-} \
-inline bool operator != (T const & lhs, T const & rhs) { \
-return !(lhs == rhs); \
-} \
+#define CAFFQL_DEFINE_EQUALS(T, equals)                                                                                \
+    inline bool operator==(T const & lhs, T const & rhs) { equals }                                                    \
+    inline bool operator!=(T const & lhs, T const & rhs) { return !(lhs == rhs); }
 
 namespace caffql {
 
-enum class TypeKind {
-    Scalar, Object, Interface, Union, Enum, InputObject, List, NonNull
-};
+enum class TypeKind { Scalar, Object, Interface, Union, Enum, InputObject, List, NonNull };
 
 enum class Scalar {
     // 32 bit
@@ -39,14 +33,9 @@ struct TypeRef {
         }
         return *this;
     }
-
 };
 
-CAFFQL_DEFINE_EQUALS(TypeRef,
-    return lhs.kind == rhs.kind
-        && lhs.name == rhs.name
-        && lhs.ofType == rhs.ofType;
-)
+CAFFQL_DEFINE_EQUALS(TypeRef, return lhs.kind == rhs.kind && lhs.name == rhs.name && lhs.ofType == rhs.ofType;)
 
 struct InputValue {
     TypeRef type;
@@ -56,10 +45,7 @@ struct InputValue {
 };
 
 CAFFQL_DEFINE_EQUALS(InputValue,
-    return lhs.type == rhs.type
-        && lhs.name == rhs.name
-        && lhs.description == rhs.description;
-)
+                     return lhs.type == rhs.type && lhs.name == rhs.name && lhs.description == rhs.description;)
 
 struct Field {
     TypeRef type;
@@ -70,11 +56,8 @@ struct Field {
 };
 
 CAFFQL_DEFINE_EQUALS(Field,
-    return lhs.type == rhs.type
-        && lhs.name == rhs.name
-        && lhs.description == rhs.description
-        && lhs.args == rhs.args;
-)
+                     return lhs.type == rhs.type && lhs.name == rhs.name && lhs.description == rhs.description &&
+                            lhs.args == rhs.args;)
 
 struct EnumValue {
     std::string name;
@@ -82,10 +65,7 @@ struct EnumValue {
     // TODO: Deprecation
 };
 
-CAFFQL_DEFINE_EQUALS(EnumValue,
-    return lhs.name == rhs.name
-        && lhs.description == rhs.description;
-)
+CAFFQL_DEFINE_EQUALS(EnumValue, return lhs.name == rhs.name && lhs.description == rhs.description;)
 
 struct Type {
     TypeKind kind;
@@ -102,26 +82,16 @@ struct Type {
     // Interface and Union only
     std::vector<TypeRef> possibleTypes;
 
-    operator TypeRef () const {
-        return {kind, name};
-    }
-
+    operator TypeRef() const { return {kind, name}; }
 };
 
 CAFFQL_DEFINE_EQUALS(Type,
-    return lhs.kind == rhs.kind
-        && lhs.name == rhs.name
-        && lhs.description == rhs.description
-        && lhs.fields == rhs.fields
-        && lhs.inputFields == rhs.inputFields
-        && lhs.interfaces == rhs.interfaces
-        && lhs.enumValues == rhs.enumValues
-        && lhs.possibleTypes == rhs.possibleTypes;
-)
+                     return lhs.kind == rhs.kind && lhs.name == rhs.name && lhs.description == rhs.description &&
+                            lhs.fields == rhs.fields && lhs.inputFields == rhs.inputFields &&
+                            lhs.interfaces == rhs.interfaces && lhs.enumValues == rhs.enumValues &&
+                            lhs.possibleTypes == rhs.possibleTypes;)
 
-enum class Operation {
-    Query, Mutation, Subscription
-};
+enum class Operation { Query, Mutation, Subscription };
 
 struct Schema {
 
@@ -138,16 +108,16 @@ struct Schema {
 
 using TypeMap = std::unordered_map<std::string, Type>;
 
-NLOHMANN_JSON_SERIALIZE_ENUM(TypeKind, {
-    {TypeKind::Scalar, "SCALAR"},
-    {TypeKind::Object, "OBJECT"},
-    {TypeKind::Interface, "INTERFACE"},
-    {TypeKind::Union, "UNION"},
-    {TypeKind::Enum, "ENUM"},
-    {TypeKind::InputObject, "INPUT_OBJECT"},
-    {TypeKind::List, "LIST"},
-    {TypeKind::NonNull, "NON_NULL"}
-});
+NLOHMANN_JSON_SERIALIZE_ENUM(
+        TypeKind,
+        {{TypeKind::Scalar, "SCALAR"},
+         {TypeKind::Object, "OBJECT"},
+         {TypeKind::Interface, "INTERFACE"},
+         {TypeKind::Union, "UNION"},
+         {TypeKind::Enum, "ENUM"},
+         {TypeKind::InputObject, "INPUT_OBJECT"},
+         {TypeKind::List, "LIST"},
+         {TypeKind::NonNull, "NON_NULL"}});
 
 void from_json(Json const & json, TypeRef & type);
 
@@ -228,31 +198,41 @@ struct QueryVariable {
     TypeRef type;
 };
 
-CAFFQL_DEFINE_EQUALS(QueryVariable,
-    return lhs.name == rhs.name
-        && lhs.type == rhs.type;
-)
+CAFFQL_DEFINE_EQUALS(QueryVariable, return lhs.name == rhs.name && lhs.type == rhs.type;)
 
 std::string appendNameToVariablePrefix(std::string const & variablePrefix, std::string const & name);
 
-std::string generateQueryFields(Type const & type, TypeMap const & typeMap, std::string const & variablePrefix, std::vector<QueryVariable> & variables, size_t indentation);
+std::string generateQueryFields(
+        Type const & type,
+        TypeMap const & typeMap,
+        std::string const & variablePrefix,
+        std::vector<QueryVariable> & variables,
+        size_t indentation);
 
-std::string generateQueryField(Field const & field, TypeMap const & typeMap, std::string const & variablePrefix, std::vector<QueryVariable> & variables, size_t indentation);
+std::string generateQueryField(
+        Field const & field,
+        TypeMap const & typeMap,
+        std::string const & variablePrefix,
+        std::vector<QueryVariable> & variables,
+        size_t indentation);
 
 struct QueryDocument {
     std::string query;
     std::vector<QueryVariable> variables;
 };
 
-QueryDocument generateQueryDocument(Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation);
+QueryDocument generateQueryDocument(
+        Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation);
 
 bool shouldPassByReferenceToRequestFunction(TypeRef const & type);
 
-std::string generateOperationRequestFunction(Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation);
+std::string generateOperationRequestFunction(
+        Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation);
 
 std::string generateOperationResponseFunction(Field const & field, size_t indentation);
 
-std::string generateOperationType(Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation);
+std::string generateOperationType(
+        Field const & field, Operation operation, TypeMap const & typeMap, size_t indentation);
 
 std::string generateOperationTypes(Type const & type, Operation operation, TypeMap const & typeMap, size_t indentation);
 
@@ -260,13 +240,11 @@ std::string generateGraphqlErrorType(size_t indentation);
 
 std::string generateGraphqlErrorDeserialization(size_t indentation);
 
-enum class AlgebraicNamespace {
-    Std,
-    Absl
-};
+enum class AlgebraicNamespace { Std, Absl };
 
 std::string algrebraicNamespaceName(AlgebraicNamespace algebraicNamespace);
 
-std::string generateTypes(Schema const & schema, std::string const & generatedNamespace, AlgebraicNamespace algebraicNamespace);
+std::string generateTypes(
+        Schema const & schema, std::string const & generatedNamespace, AlgebraicNamespace algebraicNamespace);
 
-}
+} // namespace caffql

--- a/src/Json.hpp
+++ b/src/Json.hpp
@@ -3,25 +3,25 @@
 #include "nlohmann/json.hpp"
 
 namespace nlohmann {
-    template <typename T>
-    struct adl_serializer<std::optional<T>> {
-        static void to_json(json & json, std::optional<T> const & opt) {
-            if (opt.has_value()) {
-                json = *opt;
-            } else {
-                json = nullptr;
-            }
+template <typename T>
+struct adl_serializer<std::optional<T>> {
+    static void to_json(json & json, std::optional<T> const & opt) {
+        if (opt.has_value()) {
+            json = *opt;
+        } else {
+            json = nullptr;
         }
+    }
 
-        static void from_json(const json & json, std::optional<T> & opt) {
-            if (json.is_null()) {
-                opt.reset();
-            } else {
-                opt = json.get<T>();
-            }
+    static void from_json(const json & json, std::optional<T> & opt) {
+        if (json.is_null()) {
+            opt.reset();
+        } else {
+            opt = json.get<T>();
         }
-    };
-}
+    }
+};
+} // namespace nlohmann
 
 namespace caffql {
 
@@ -42,4 +42,4 @@ void get_value_to(Json const & json, char const * key, std::optional<T> & target
     }
 }
 
-}
+} // namespace caffql

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
+#include <fstream>
 #include "CodeGeneration.hpp"
 #include "cxxopts.hpp"
-#include <fstream>
 
 namespace caffql {
 
@@ -13,13 +13,14 @@ struct ProgramInputs {
 
 ProgramInputs parseCommandLine(int argc, char * argv[]) {
     try {
-        cxxopts::Options options("caffql", "Generate c++ types and GraphQL request and response serialization from a GraphQL json schema file.");
-        options.add_options()
-        ("s,schema", "input json schema file", cxxopts::value<std::string>())
-        ("o,output", "output generated header file", cxxopts::value<std::string>())
-        ("n,namespace", "generated namespace", cxxopts::value<std::string>()->default_value("caffql"))
-        ("a,absl", "use absl optional and variant instead of std")
-        ("h,help", "help");
+        cxxopts::Options options(
+                "caffql",
+                "Generate c++ types and GraphQL request and response serialization from a GraphQL json schema "
+                "file.");
+        options.add_options()("s,schema", "input json schema file", cxxopts::value<std::string>())(
+                "o,output", "output generated header file", cxxopts::value<std::string>())(
+                "n,namespace", "generated namespace", cxxopts::value<std::string>()->default_value("caffql"))(
+                "a,absl", "use absl optional and variant instead of std")("h,help", "help");
 
         auto result = options.parse(argc, argv);
 
@@ -38,19 +39,17 @@ ProgramInputs parseCommandLine(int argc, char * argv[]) {
             exit(1);
         }
 
-        return {
-            result["schema"].as<std::string>(),
-            result["output"].as<std::string>(),
-            result["namespace"].as<std::string>(),
-            result.count("absl") ? AlgebraicNamespace::Absl : AlgebraicNamespace::Std
-        };
+        return {result["schema"].as<std::string>(),
+                result["output"].as<std::string>(),
+                result["namespace"].as<std::string>(),
+                result.count("absl") ? AlgebraicNamespace::Absl : AlgebraicNamespace::Std};
     } catch (cxxopts::OptionException const & e) {
         printf("Error parsing options: %s\n", e.what());
         exit(1);
     }
 }
 
-}
+} // namespace caffql
 
 int main(int argc, char * argv[]) {
     using namespace caffql;

--- a/tests/src/BoxedOptionalTests.cpp
+++ b/tests/src/BoxedOptionalTests.cpp
@@ -1,5 +1,5 @@
-#include "doctest.h"
 #include "BoxedOptional.hpp"
+#include "doctest.h"
 
 using namespace caffql;
 
@@ -51,7 +51,6 @@ TEST_CASE("deserialization") {
         BoxedOptional<std::string> x = Json(nullptr);
         CHECK_FALSE(x);
     }
-
 }
 
 TEST_SUITE_END;

--- a/tests/src/CodeGenerationTests.cpp
+++ b/tests/src/CodeGenerationTests.cpp
@@ -1,5 +1,5 @@
-#include "doctest.h"
 #include "CodeGeneration.hpp"
+#include "doctest.h"
 
 using namespace caffql;
 
@@ -14,7 +14,8 @@ TEST_CASE("custom type sorting") {
         // Has field of type A and possible type B
         Type c{TypeKind::Interface, "C", "", {Field{a, "a"}}, {}, {}, {}, {b}};
         // Has field of type [C!]!
-        TypeRef nonNullListOfNonNullC{TypeKind::NonNull, {}, TypeRef{TypeKind::List, {}, TypeRef{TypeKind::NonNull, {}, {c}}}};
+        TypeRef nonNullListOfNonNullC{
+                TypeKind::NonNull, {}, TypeRef{TypeKind::List, {}, TypeRef{TypeKind::NonNull, {}, {c}}}};
         Type d{TypeKind::Object, "D", "", {Field{nonNullListOfNonNullC}}};
         // Union of possible types A, B, C, D
         Type e{TypeKind::Union, "E", "", {}, {}, {}, {}, {a, b, c, d}};
@@ -37,7 +38,6 @@ TEST_CASE("custom type sorting") {
         auto types = sortCustomTypesByDependencyOrder({{TypeKind::Scalar}, {TypeKind::List}, {TypeKind::NonNull}});
         CHECK(types.empty());
     }
-
 }
 
 TEST_CASE("string conversion functions") {
@@ -51,7 +51,9 @@ TEST_CASE("cpp type name") {
     CHECK(cppTypeName(objectType) == "optional<Object>");
     CHECK(cppTypeName(TypeRef{TypeKind::NonNull, {}, objectType}) == "Object");
     CHECK(cppTypeName(TypeRef{TypeKind::List, {}, objectType}) == "optional<std::vector<optional<Object>>>");
-    CHECK(cppTypeName(TypeRef{TypeKind::NonNull, {}, TypeRef{TypeKind::List, {}, TypeRef{TypeKind::NonNull, {}, objectType}}}) == "std::vector<Object>");
+    CHECK(cppTypeName(TypeRef{
+                  TypeKind::NonNull, {}, TypeRef{TypeKind::List, {}, TypeRef{TypeKind::NonNull, {}, objectType}}}) ==
+          "std::vector<Object>");
 }
 
 TEST_CASE("graphql type name") {
@@ -59,18 +61,16 @@ TEST_CASE("graphql type name") {
     CHECK(graphqlTypeName(objectType) == "Object");
     CHECK(graphqlTypeName(TypeRef{TypeKind::NonNull, {}, objectType}) == "Object!");
     CHECK(graphqlTypeName(TypeRef{TypeKind::List, {}, objectType}) == "[Object]");
-    CHECK(graphqlTypeName(TypeRef{TypeKind::NonNull, {}, TypeRef{TypeKind::List, {}, TypeRef{TypeKind::NonNull, {}, objectType}}}) == "[Object!]!");
+    CHECK(graphqlTypeName(TypeRef{
+                  TypeKind::NonNull, {}, TypeRef{TypeKind::List, {}, TypeRef{TypeKind::NonNull, {}, objectType}}}) ==
+          "[Object!]!");
 }
 
 TEST_CASE("description generation") {
 
-    SUBCASE("null description generates nothing") {
-        CHECK(generateDescription(std::nullopt, 0) == "");
-    }
+    SUBCASE("null description generates nothing") { CHECK(generateDescription(std::nullopt, 0) == ""); }
 
-    SUBCASE("empty description generates nothing") {
-        CHECK(generateDescription("", 0) == "");
-    }
+    SUBCASE("empty description generates nothing") { CHECK(generateDescription("", 0) == ""); }
 
     SUBCASE("Description with no line breaks generates a single-line comment bounded by line breaks") {
         CHECK(generateDescription("Description", 0) == "// Description\n");
@@ -87,7 +87,6 @@ TEST_CASE("description generation") {
 )";
         CHECK("\n" + generateDescription(description, 2) == expected);
     }
-
 }
 
 TEST_CASE("enum generation") {
@@ -118,20 +117,14 @@ TEST_CASE("enum generation") {
 )";
         CHECK("\n" + generateEnumSerialization(enumType, 2) == expected);
     }
-    
 }
 
 TEST_CASE("interface generation") {
     Type interfaceType{TypeKind::Interface, "InterfaceType"};
 
-    interfaceType.fields = {
-        Field{TypeRef{TypeKind::NonNull, "", TypeRef{TypeKind::Object, "FieldType"}}, "field"}
-    };
+    interfaceType.fields = {Field{TypeRef{TypeKind::NonNull, "", TypeRef{TypeKind::Object, "FieldType"}}, "field"}};
 
-    interfaceType.possibleTypes = {
-        TypeRef{TypeKind::Object, "A"},
-        TypeRef{TypeKind::Object, "B"}
-    };
+    interfaceType.possibleTypes = {TypeRef{TypeKind::Object, "A"}, TypeRef{TypeKind::Object, "B"}};
 
     SUBCASE("type") {
         std::string expected = R"(
@@ -174,15 +167,11 @@ TEST_CASE("interface generation") {
 )";
         CHECK("\n" + generateInterfaceDeserialization(interfaceType, 2) == expected);
     }
-
 }
 
 TEST_CASE("union generation") {
     Type unionType{TypeKind::Union, "UnionType"};
-    unionType.possibleTypes = {
-        TypeRef{TypeKind::Object, "A"},
-        TypeRef{TypeKind::Object, "B"}
-    };
+    unionType.possibleTypes = {TypeRef{TypeKind::Object, "A"}, TypeRef{TypeKind::Object, "B"}};
 
     SUBCASE("type") {
         std::string expected = R"(
@@ -209,14 +198,11 @@ TEST_CASE("union generation") {
 )";
         CHECK("\n" + generateUnionDeserialization(unionType, 2) == expected);
     }
-
 }
 
 TEST_CASE("object generation") {
     Type objectType{TypeKind::Object, "ObjectType"};
-    objectType.fields = {
-        Field{TypeRef{TypeKind::NonNull, {}, TypeRef{TypeKind::Object, "FieldType"}}, "field"}
-    };
+    objectType.fields = {Field{TypeRef{TypeKind::NonNull, {}, TypeRef{TypeKind::Object, "FieldType"}}, "field"}};
 
     SUBCASE("type") {
         std::string expected = R"(
@@ -243,8 +229,7 @@ TEST_CASE("object generation") {
 TEST_CASE("input object generation") {
     Type inputObjectType{TypeKind::InputObject, "InputObjectType"};
     inputObjectType.inputFields = {
-        InputValue{TypeRef{TypeKind::NonNull, {}, TypeRef{TypeKind::InputObject, "InputFieldType"}}, "field"}
-    };
+            InputValue{TypeRef{TypeKind::NonNull, {}, TypeRef{TypeKind::InputObject, "InputFieldType"}}, "field"}};
 
     SUBCASE("type") {
         std::string expected = R"(
@@ -273,25 +258,28 @@ TEST_CASE("request function argument passing") {
         CHECK_FALSE(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::Scalar, "Int"}));
         CHECK_FALSE(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::Scalar, "Float"}));
         CHECK_FALSE(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::Scalar, "Boolean"}));
-        CHECK_FALSE(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::NonNull, {}, {TypeRef{TypeKind::Scalar, "Int"}}}));
+        CHECK_FALSE(shouldPassByReferenceToRequestFunction(
+                TypeRef{TypeKind::NonNull, {}, {TypeRef{TypeKind::Scalar, "Int"}}}));
     }
 
     SUBCASE("string primitive types should be passed by reference") {
         CHECK(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::Scalar, "String"}));
         CHECK(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::Scalar, "ID"}));
-        CHECK(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::NonNull, {}, {TypeRef{TypeKind::Scalar, "String"}}}));
+        CHECK(shouldPassByReferenceToRequestFunction(
+                TypeRef{TypeKind::NonNull, {}, {TypeRef{TypeKind::Scalar, "String"}}}));
     }
 
     SUBCASE("lists should be passed by reference") {
         CHECK(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::List, {}, {TypeRef{TypeKind::Scalar, "Int"}}}));
-        CHECK(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::NonNull, {}, TypeRef{TypeKind::List, {}, {TypeRef{TypeKind::Scalar, "Int"}}}}));
+        CHECK(shouldPassByReferenceToRequestFunction(
+                TypeRef{TypeKind::NonNull, {}, TypeRef{TypeKind::List, {}, {TypeRef{TypeKind::Scalar, "Int"}}}}));
     }
 
     SUBCASE("input objects should be passed by reference") {
         CHECK(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::InputObject, "InputType"}));
-        CHECK(shouldPassByReferenceToRequestFunction(TypeRef{TypeKind::NonNull, {}, { TypeRef{TypeKind::InputObject, "InputType"}}}));
+        CHECK(shouldPassByReferenceToRequestFunction(
+                TypeRef{TypeKind::NonNull, {}, {TypeRef{TypeKind::InputObject, "InputType"}}}));
     }
-
 }
 
 TEST_CASE("query field generation") {
@@ -310,15 +298,11 @@ TEST_CASE("query field generation") {
 
     SUBCASE("object field") {
         Type subobjectType{TypeKind::Object, "Subobject"};
-        subobjectType.fields = {
-            Field{TypeRef{TypeKind::Scalar, "Float"}, "floatField"}
-        };
+        subobjectType.fields = {Field{TypeRef{TypeKind::Scalar, "Float"}, "floatField"}};
 
         Type objectType{TypeKind::Object, "Object"};
-        objectType.fields = {
-            Field{TypeRef{TypeKind::Scalar, "Int"}, "intField"},
-            Field{subobjectType, "subobjectField"}
-        };
+        objectType.fields = {Field{TypeRef{TypeKind::Scalar, "Int"}, "intField"},
+                             Field{subobjectType, "subobjectField"}};
 
         typeMap = {{"Object", objectType}, {"Subobject", subobjectType}};
 
@@ -338,9 +322,7 @@ TEST_CASE("query field generation") {
 
     SUBCASE("interface field") {
         Type interfaceType{TypeKind::Interface, "Interface"};
-        interfaceType.fields = {
-            Field{TypeRef{TypeKind::Scalar, "Int"}, "intField"}
-        };
+        interfaceType.fields = {Field{TypeRef{TypeKind::Scalar, "Int"}, "intField"}};
 
         Type impA{TypeKind::Object, "ImpA"};
         impA.fields = interfaceType.fields;
@@ -375,14 +357,10 @@ TEST_CASE("query field generation") {
         Type unionType{TypeKind::Union, "Union"};
 
         Type impA{TypeKind::Object, "ImpA"};
-        impA.fields = {
-            Field{TypeRef{TypeKind::Scalar, "Int"}, "intField"}
-        };
+        impA.fields = {Field{TypeRef{TypeKind::Scalar, "Int"}, "intField"}};
 
         Type impB{TypeKind::Object, "ImpB"};
-        impB.fields = {
-            Field{TypeRef{TypeKind::Scalar, "Float"}, "floatField"}
-        };
+        impB.fields = {Field{TypeRef{TypeKind::Scalar, "Float"}, "floatField"}};
 
         unionType.possibleTypes = {impA, impB};
 
@@ -409,9 +387,10 @@ TEST_CASE("query field generation") {
         Field field{TypeRef{TypeKind::Scalar, "Int"}, "field"};
 
         field.args = {
-            InputValue{TypeRef{TypeKind::Scalar, "Int"}, "argA"},
-            InputValue{TypeRef{TypeKind::NonNull, {}, TypeRef{TypeKind::List, {}, TypeRef{TypeKind::Scalar, "Int"}}}, "argB"}
-        };
+                InputValue{TypeRef{TypeKind::Scalar, "Int"}, "argA"},
+                InputValue{
+                        TypeRef{TypeKind::NonNull, {}, TypeRef{TypeKind::List, {}, TypeRef{TypeKind::Scalar, "Int"}}},
+                        "argB"}};
 
         auto expected = R"(
         field(
@@ -422,10 +401,8 @@ TEST_CASE("query field generation") {
 
         CHECK("\n" + generateQueryField(field, typeMap, "", variables, 2) == expected);
 
-        std::vector<QueryVariable> expectedVariables{
-            {field.args[0].name, field.args[0].type},
-            {field.args[1].name, field.args[1].type}
-        };
+        std::vector<QueryVariable> expectedVariables{{field.args[0].name, field.args[0].type},
+                                                     {field.args[1].name, field.args[1].type}};
 
         CHECK(variables == expectedVariables);
     }
@@ -434,9 +411,7 @@ TEST_CASE("query field generation") {
         Type objectType{TypeKind::Object, "Object"};
         Field nestedField{TypeRef{TypeKind::Scalar, "Int"}, "nestedField"};
 
-        nestedField.args = {
-            InputValue{TypeRef{TypeKind::Scalar, "Int"}, "nestedArg"}
-        };
+        nestedField.args = {InputValue{TypeRef{TypeKind::Scalar, "Int"}, "nestedArg"}};
 
         objectType.fields = {nestedField};
 
@@ -454,13 +429,10 @@ TEST_CASE("query field generation") {
 
         CHECK("\n" + generateQueryField(field, typeMap, "", variables, 2) == expected);
 
-        std::vector<QueryVariable> expectedVariables{
-            {"objectNestedFieldNestedArg", nestedField.args[0].type}
-        };
+        std::vector<QueryVariable> expectedVariables{{"objectNestedFieldNestedArg", nestedField.args[0].type}};
 
         CHECK(variables == expectedVariables);
     }
-
 }
 
 TEST_SUITE_END;


### PR DESCRIPTION
This is identical to libcaffeine's clang-format except for these values:
`AlwaysBreakTemplateDeclarations: true`
`Cpp11BracedListStyle: true`
`NamespaceIndentation: Inner`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/caffql/4)
<!-- Reviewable:end -->
