### PR TITLE
Add operation to operation fields

### DIFF
--- a/src/CodeGeneration.cpp
+++ b/src/CodeGeneration.cpp
@@ -765,6 +765,9 @@ std::string generateOperationType(
     generated += generateDescription(field.description, indentation);
     generated += indent(indentation) + "struct " + capitalize(field.name) + "Field" + " {\n\n";
 
+    generated += indent(indentation + 1) +
+                 "static Operation constexpr operation = Operation::" + capitalize(operationQueryName(operation)) +
+                 ";\n\n";
     generated += generateOperationRequestFunction(field, operation, typeMap, indentation + 1);
     generated += generateOperationResponseFunction(field, indentation + 1);
 
@@ -921,6 +924,8 @@ std::string generateTypes(
     useAlgebraic("monostate");
     useAlgebraic("visit");
     source += "\n";
+
+    source += indent(typeIndentation) + "enum class Operation { Query, Mutation, Subscription };\n\n";
 
     source += generateGraphqlErrorType(typeIndentation);
     source += generateGraphqlErrorDeserialization(typeIndentation);


### PR DESCRIPTION
This way clients can validate the right request functions are used for the right operation types.
See [this pr](https://github.com/caffeinetv/libcaffeine/pull/83) for a usage example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/caffql/5)
<!-- Reviewable:end -->
