### PR TITLE
Interface query generation updates

### DIFF
--- a/src/CodeGeneration.hpp
+++ b/src/CodeGeneration.hpp
@@ -207,6 +207,7 @@ std::string generateQueryFields(
         TypeMap const & typeMap,
         std::string const & variablePrefix,
         std::vector<QueryVariable> & variables,
+        std::vector<Field> const & ignoredFields,
         size_t indentation);
 
 std::string generateQueryField(

--- a/tests/src/CodeGenerationTests.cpp
+++ b/tests/src/CodeGenerationTests.cpp
@@ -340,12 +340,9 @@ TEST_CASE("query field generation") {
         auto expected = R"(
         field {
             __typename
+            intField
             ...on ImpA {
-                intField
                 floatField
-            }
-            ...on ImpB {
-                intField
             }
         }
 )";


### PR DESCRIPTION
Query interface fields as part of the interface query instead of for each implementation.

This makes sure the interface fields are present so unknown interface objects can be properly deserialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/caffql/6)
<!-- Reviewable:end -->
