### PR TITLE
Fix for: Invalid requests generated for queries without input variables

### DIFF
--- a/src/CodeGeneration.cpp
+++ b/src/CodeGeneration.cpp
@@ -642,13 +642,17 @@ QueryDocument generateQueryDocument(
 
     auto selectionSet = generateQueryField(field, typeMap, "", variables, indentation + 1);
 
-    query += indent(indentation) + operationQueryName(operation) + " " + capitalize(field.name) + "(\n";
+    query += indent(indentation) + operationQueryName(operation) + " " + capitalize(field.name);
 
-    for (auto const & variable : variables) {
-        query += indent(indentation + 1) + "$" + variable.name + ": " + graphqlTypeName(variable.type) + "\n";
+    if (variables.size()) {
+        query += "(\n";
+        for (auto const & variable : variables) {
+            query += indent(indentation + 1) + "$" + variable.name + ": " + graphqlTypeName(variable.type) + "\n";
+        }
+        query += indent(indentation) + ")";
     }
 
-    query += indent(indentation) + ") {\n";
+    query += " {\n";
     query += selectionSet;
     query += indent(indentation) + "}\n";
 


### PR DESCRIPTION
When generating requests for queries without any variables the query becomes: 

```javascript
static Json request() {
    Json query = R"(
        query Orders(
        ) {
            orders {
                id
                orderNo
            }
        }
    )";
    Json variables;
    return {{"query", std::move(query)}, {"variables", std::move(variables)}};
}
```

This results in an error when sending the query to my GraphQL API because of the empty variables input **query Orders( ) { .... }** it should be **query Orders { ... }**.